### PR TITLE
Ensure contact['url'] is always a list

### DIFF
--- a/ckanext/dcat/profiles/base.py
+++ b/ckanext/dcat/profiles/base.py
@@ -658,7 +658,8 @@ class RDFProfile(object):
 
             contact["identifier"] = self._get_vcard_property_value(agent, VCARD.hasUID)
 
-            contact["url"] = self._get_vcard_property_value(agent, VCARD.hasURL)
+            url_value = self._get_vcard_property_value(agent, VCARD.hasURL)
+            contact["url"] = [url_value] if url_value else []
 
             contacts.append(contact)
 

--- a/ckanext/dcat/tests/profiles/dcat_ap_3/test_euro_dcatap_3_profile_parse.py
+++ b/ckanext/dcat/tests/profiles/dcat_ap_3/test_euro_dcatap_3_profile_parse.py
@@ -102,7 +102,7 @@ class TestSchemingParseSupport(BaseParseTest):
 
         assert dataset["contact"][0]["name"] == "Point of Contact"
         assert dataset["contact"][0]["email"] == "contact@some.org"
-        assert dataset["contact"][0]["url"] == "https://example.org"
+        assert dataset["contact"][0]["url"] == ["https://example.org"]
 
         assert (
             dataset["publisher"][0]["name"] == "Publishing Organization for dataset 1"


### PR DESCRIPTION
Wrap the extracted vCard URL value in a list (or use an empty list when absent) so contact['url'] consistently has a list type. This avoids type errors in downstream code that expects an iterable of URLs.